### PR TITLE
chore: prevent protobuf breaking changes

### DIFF
--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -26,7 +26,7 @@ jobs:
           version: 1.0.0-rc11
 
       - name: Lint
-        run: buf lint api
+        run: make lint.proto
 
       - name: Setup protoc
         uses: arduino/setup-protoc@v1.1.2

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,15 @@ generate:
 	cd rn && npx ts-node src/create-mod/gen-go-modules-list
 .PHONY: generate
 
+lint.proto:
+	buf lint api
+	buf breaking --against 'https://github.com/berty/labs.git'
+.PHONY: lint.proto
+
+lint: lint.proto
+	$(MAKE) -C rn lint
+.PHONY: lint
+
 regen: clean.gen
 	$(MAKE) generate
 .PHONY: regen


### PR DESCRIPTION
example error:
```
❯ make lint
buf lint api
buf breaking --against 'https://github.com/berty/labs.git'
api/blmod/v1/blmod.proto:7:1:Previously present field "5" with name "short_description" on message "ModuleInfo" was deleted.
make: *** [lint.proto] Error 100
```